### PR TITLE
👷 Create dependabot.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    assignees:
+      - "asimpleidea"
+    commit-message:
+      prefix: "⬆️"
+      include: "scope"
+    reviewers:
+      - "asimpleidea"
+      - "arnatal"
+      - "ljakab"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Dependabot is now configured to track versions of dependencies used by the project
and create PRs accordingly.

What it does:
- check *daily* for dependencies version updates
- assign the PRs that it creates to me
- sets labels to `dependencies`
- sets the owners of the project as reviewers
- adds some prefixes to the PR