### PR TITLE
Check existing custom apps

### DIFF
--- a/pkg/sdwan/error.go
+++ b/pkg/sdwan/error.go
@@ -18,7 +18,14 @@
 
 package sdwan
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrNotFound error = errors.New("resource not found")
+)
 
 type Error struct {
 	Type    string `json:"type"`

--- a/pkg/sdwan/vmanage/policy.go
+++ b/pkg/sdwan/vmanage/policy.go
@@ -36,6 +36,7 @@ const (
 
 	customAppPath      string = "template/policy/customapp"
 	appsListPolicyPath string = "template/policy/list/app"
+	listCustomAppsPath string = "template/policy/customapp"
 )
 
 type policyOps struct {
@@ -265,4 +266,30 @@ func (p *policyOps) GetApplicationListByName(ctx context.Context, name string) (
 	}
 
 	return nil, fmt.Errorf("not found")
+}
+
+func (p *policyOps) ListCustomApplications(ctx context.Context) ([]*policy.CustomApplication, error) {
+	u := url.URL{Path: listCustomAppsPath}
+	_, bodyResp, err := p.vclient.do(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not perform request: %w", err)
+	}
+
+	// --------------------------------
+	// Parse the response
+	// --------------------------------
+
+	var appLists []*policy.CustomApplication
+	{
+		data, err := getRawMessageFromResponseBody(bodyResp, "data")
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(data, &appLists); err != nil {
+			return nil, fmt.Errorf("could not unmarshal response body: %w", err)
+		}
+	}
+
+	return appLists, nil
 }

--- a/pkg/sdwan/vmanage/policy.go
+++ b/pkg/sdwan/vmanage/policy.go
@@ -28,6 +28,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/CloudNativeSDWAN/egress-watcher/pkg/sdwan"
 	"github.com/CloudNativeSDWAN/egress-watcher/pkg/sdwan/vmanage/types/policy"
 )
 
@@ -265,7 +266,7 @@ func (p *policyOps) GetApplicationListByName(ctx context.Context, name string) (
 		}
 	}
 
-	return nil, fmt.Errorf("not found")
+	return nil, sdwan.ErrNotFound
 }
 
 func (p *policyOps) ListCustomApplications(ctx context.Context) ([]*policy.CustomApplication, error) {


### PR DESCRIPTION
This PR includes changes to how SDWAN handles creation of applications/policies: for example, in case vManage is selected, a full list of custom applications already being enforced/defined will be pulled prior to creation, avoiding duplicates or errors.

This fixes #9.