### PR TITLE
Human readable logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ To ignore a service entry you will have to label it as
 * `--sdwan.username`: the username for authentication. **Required**.
 * `--sdwan.password`: the password for authentication. **Required**.
 * `--sdwan.insecure`: whether to accept self-signed certificates.
+* `--pretty-logs`: whether to log data in a slower but human readable format.
 
 As a rule of thumb, remember that flag options **overwrite** options provided
 via file.
@@ -178,5 +179,5 @@ Before starting, please make sure you know and agree to our [Code of conduct](./
 
 Egress Watcher is free and open-source software licensed under the *Apache 2.0*
 License.
-                            
+
 Refer to [our license file](https://github.com/CloudNativeSDWAN/egress-watcher/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ To ignore a service entry you will have to label it as
 * `--sdwan.password`: the password for authentication. **Required**.
 * `--sdwan.insecure`: whether to accept self-signed certificates.
 * `--pretty-logs`: whether to log data in a slower but human readable format.
+* `--verbosity`: to set up the verbosity level. It can be from `0` (most
+* verbose) to `3` (only log important errors).
 
 As a rule of thumb, remember that flag options **overwrite** options provided
 via file.

--- a/settings.yaml
+++ b/settings.yaml
@@ -8,3 +8,4 @@ sdwan:
   baseUrl: <base_url>
   insecure: false
   prettyLogs: false
+  verbosity: 1

--- a/settings.yaml
+++ b/settings.yaml
@@ -7,3 +7,4 @@ sdwan:
   # e.g: https://example.com:9876/api
   baseUrl: <base_url>
   insecure: false
+  prettyLogs: false


### PR DESCRIPTION
This PR addresses #10, although in a different way from what is explained in the issue.

It brings human readable logs to the project via the `--pretty-logs` flag, independently of the verbosity level.
By default it is set to `false` as it is intended to be used for testing/debugging/examples.