### PR TITLE
Configurable waiting window

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ To ignore a service entry you will have to label it as
 * `--sdwan.insecure`: whether to accept self-signed certificates.
 * `--pretty-logs`: whether to log data in a slower but human readable format.
 * `--verbosity`: to set up the verbosity level. It can be from `0` (most
-* verbose) to `3` (only log important errors).
+* verbose) to `3` (only log important errors). Default is `1`.
+* `--waiting-window`: the duration of the waiting mode. Set this to 0 to
+  disable it entirely. For example, if you set `1m`, Egress Watcher will
+  wait one minute for other changes to appear before applying them in
+  order to improve performance and do bulk operations. Default is `30s`.
 
 As a rule of thumb, remember that flag options **overwrite** options provided
 via file.

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -135,6 +135,10 @@ The following controllers are supported:
 					opts.Sdwan.BaseURL = flagOpts.Sdwan.BaseURL
 				}
 
+				if cmd.Flag("waiting-window").Changed {
+					opts.Sdwan.WaitingWindow = flagOpts.Sdwan.WaitingWindow
+				}
+
 				if cmd.Flag("sdwan.insecure").Changed {
 					opts.Sdwan.Insecure = flagOpts.Sdwan.Insecure
 				}
@@ -142,6 +146,10 @@ The following controllers are supported:
 
 			if _, err := url.Parse(opts.Sdwan.BaseURL); err != nil {
 				return fmt.Errorf("invalid base url provided: %w", err)
+			}
+
+			if *opts.Sdwan.WaitingWindow < 0 {
+				return fmt.Errorf("invalid waiting window provided")
 			}
 
 			if cmd.Flag("watch-all-service-entries").Changed {
@@ -190,6 +198,9 @@ The following controllers are supported:
 	cmd.Flags().BoolVar(&flagOpts.PrettyLogs,
 		"pretty-logs", false,
 		"whether to log data in a slower but human readable format.")
+	cmd.Flags().DurationVar(flagOpts.Sdwan.WaitingWindow,
+		"waiting-window", sdwan.DefaultWaitingWindow,
+		"the duration of the waiting mode. Set this to 0 to disable it entirely.")
 
 	return cmd
 }

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -273,7 +273,7 @@ func runWithVmanage(kopts *kubeConfigOptions, opts *Options) error {
 		go func() {
 			defer close(exitWatch)
 
-			if err = vclient.WatchForOperations(ctx, opsChan, log); err != nil {
+			if err = vclient.WatchForOperations(ctx, opsChan, *opts.Sdwan.WaitingWindow, log); err != nil {
 				log.Err(err).Msg("error while watch for operations")
 				return
 			}

--- a/pkg/sdwan/options.go
+++ b/pkg/sdwan/options.go
@@ -3,7 +3,7 @@ package sdwan
 import "time"
 
 const (
-	DefaultWaitingWindow time.Duration = time.Minute
+	DefaultWaitingWindow time.Duration = 30 * time.Second
 )
 
 type Authentication struct {

--- a/pkg/sdwan/options.go
+++ b/pkg/sdwan/options.go
@@ -1,5 +1,11 @@
 package sdwan
 
+import "time"
+
+const (
+	DefaultWaitingWindow time.Duration = time.Minute
+)
+
 type Authentication struct {
 	Username  string
 	Password  string
@@ -8,8 +14,8 @@ type Authentication struct {
 }
 
 type Options struct {
-	BaseURL  string `yaml:"baseUrl"`
-	Insecure bool   `yaml:"insecure"`
-
+	BaseURL        string         `yaml:"baseUrl"`
+	Insecure       bool           `yaml:"insecure"`
+	WaitingWindow  *time.Duration `yaml:"waitingWindow"`
 	Authentication *Authentication
 }

--- a/pkg/sdwan/vmanage/operation.go
+++ b/pkg/sdwan/vmanage/operation.go
@@ -33,17 +33,16 @@ import (
 )
 
 const (
-	defaultWaitingTimer  time.Duration = time.Minute
 	defaultOpTimeout     time.Duration = 5 * time.Minute
 	defaultReauthTimeout time.Duration = 30 * time.Second
 )
 
-func (v *Client) WatchForOperations(mainCtx context.Context, opsChan chan *sdwan.Operation, log zerolog.Logger) error {
+func (v *Client) WatchForOperations(mainCtx context.Context, opsChan chan *sdwan.Operation, waitingWindow time.Duration, log zerolog.Logger) error {
 	toRemove, toAdd := []*sdwan.Operation{}, []*sdwan.Operation{}
 
 	// We stop it immediately, because we only want it to be active
 	// when we have at least one operation.
-	waitingTimer := time.NewTimer(defaultWaitingTimer)
+	waitingTimer := time.NewTimer(waitingWindow)
 	waitingTimer.Stop()
 
 	log.Info().Msg("worker in free mode")
@@ -61,8 +60,11 @@ func (v *Client) WatchForOperations(mainCtx context.Context, opsChan chan *sdwan
 				Msg("received operation request")
 
 			if len(toRemove) == 0 && len(toAdd) == 0 {
-				log.Info().Str("waiting-duration", defaultWaitingTimer.String()).Msg("starting waiting mode")
-				waitingTimer = time.NewTimer(defaultWaitingTimer)
+				waitingTimer = time.NewTimer(waitingWindow)
+
+				if waitingWindow > 0 {
+					log.Info().Str("waiting-duration", waitingWindow.String()).Msg("starting waiting mode")
+				}
 			}
 
 			switch op.Type {
@@ -74,7 +76,7 @@ func (v *Client) WatchForOperations(mainCtx context.Context, opsChan chan *sdwan
 				log.Error().Str("type", string(op.Type)).Msg("invalid operation type provided: skipping...")
 			}
 		case <-waitingTimer.C:
-			log.Info().Msg("busy mode activated")
+			log.Info().Msg("worker in busy mode")
 
 			if err := func() error {
 				log.Debug().Msg("checking authentication...")

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,4 +9,4 @@ sdwan:
   insecure: false
   prettyLogs: false
   verbosity: 1
-  waitingWindow: 1m
+  waitingWindow: 30s

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,3 +9,4 @@ sdwan:
   insecure: false
   prettyLogs: false
   verbosity: 1
+  waitingWindow: 1m


### PR DESCRIPTION
This addresses #6:

A new flag `--waiting-window` is introduced, which defines a custom waiting duration before applying changes. It can be set to any duration value depending on user's needs and can be disabled entirely with a 0 value.

In this latter case an additional performance step is done, as the queue will be completely depleted before actually working in case other events are waiting as well. This improves performance because it still allows the worker and the SDWAN to work in bulk mode, instead of just starting working after the first operation/event is received.