### PR TITLE
Annotate kubernetes resources

### DIFF
--- a/artifacts/yamls/k8s/01_service_account.yaml
+++ b/artifacts/yamls/k8s/01_service_account.yaml
@@ -11,22 +11,24 @@ metadata:
   creationTimestamp: null
   name: egress-watcher-role
 rules:
-- apiGroups:
-  - networking.istio.io
-  resources:
-  - serviceentries
-  verbs:
-  - watch
-  - get
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-  - get
-  - list
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - serviceentries
+    verbs:
+      - watch
+      - get
+      - list
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - get
+      - list
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/annotations/handler.go
+++ b/pkg/annotations/handler.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 Cisco Systems, Inc. and its affiliates
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package annotations
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	insertedAnnotation string = "egress-watcher.cnwan.io/sdwan-populated"
+	enabledAnnotation  string = "egress-watcher.cnwan.io/sdwan-enabled"
+)
+
+type handler struct {
+	client.Client
+	log zerolog.Logger
+}
+
+type OperationType string
+
+const (
+	// OperationEnabled means that the object has been enabled, i.e. the SDWAN
+	// applied configuration and policies to optimize traffic for this
+	// application.
+	OperationEnabled OperationType = "enabled"
+	// OperationInserted means that the object has been inserted into SDWAN's
+	// database.
+	OperationInserted OperationType = "inserted"
+	// OperationDisabled is the opposite OperationEnabled, but the application
+	// still is present in SDWAN's database.
+	OperationDisabled OperationType = "disabled"
+	// OperationRemoved means that the application/object was removed from
+	// SDWAN's database.
+	OperationRemoved OperationType = "removed"
+)
+
+// TODO: might use the definition from each of these packages instead of
+// defining them as strings here.
+type ObjectType string
+
+const (
+	ServiceEntry  ObjectType = "serviceentry"
+	NetworkPolicy ObjectType = "networkpolicy"
+)
+
+// Operation contains data about the operation just performed by SDWAN that
+// must be reflected as annotation on the object.
+type Operation struct {
+	// The object to annotate.
+	Object Object
+	// The type of the operation that was performed.
+	Type OperationType
+}
+
+// Object that originated this event.
+type Object struct {
+	// Name of the object.
+	Name types.NamespacedName
+	// Type of object.
+	Type ObjectType
+}
+
+func WatchForUpdates(ctx context.Context, client client.Client, opsChan chan *Operation, log zerolog.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		case op := <-opsChan:
+			// TODO
+			_ = op
+		}
+	}
+}

--- a/pkg/controllers/network_policy.go
+++ b/pkg/controllers/network_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco Systems, Inc. and its affiliates
+// Copyright (c) 2022, 2023 Cisco Systems, Inc. and its affiliates
 // All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,9 +23,11 @@ import (
 	"net"
 	"reflect"
 
+	"github.com/CloudNativeSDWAN/egress-watcher/pkg/annotations"
 	"github.com/CloudNativeSDWAN/egress-watcher/pkg/sdwan"
 	"github.com/rs/zerolog"
 	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/util/workqueue"
@@ -87,6 +89,11 @@ func (n *netPolsEventHandler) Update(ue event.UpdateEvent, wq workqueue.RateLimi
 		return
 	}
 
+	obj := annotations.Object{
+		Name: types.NamespacedName{Name: curr.Name, Namespace: curr.Namespace},
+		Type: annotations.NetworkPolicy,
+	}
+
 	currParsedIps := getIps(curr)
 	oldParsedIps := getIps(old)
 
@@ -113,6 +120,7 @@ func (n *netPolsEventHandler) Update(ue event.UpdateEvent, wq workqueue.RateLimi
 			Type:            sdwan.OperationRemove,
 			ApplicationName: curr.Name,
 			Servers:         oldParsedIps,
+			OriginalObject:  obj,
 		}
 		return
 	} else {
@@ -134,6 +142,7 @@ func (n *netPolsEventHandler) Update(ue event.UpdateEvent, wq workqueue.RateLimi
 					Type:            sdwan.OperationRemove,
 					ApplicationName: curr.Name,
 					Servers:         oldParsedIps,
+					OriginalObject:  obj,
 				}
 				return
 			}
@@ -156,6 +165,7 @@ func (n *netPolsEventHandler) Update(ue event.UpdateEvent, wq workqueue.RateLimi
 			Type:            sdwan.OperationRemove,
 			ApplicationName: curr.Name,
 			Servers:         oldParsedIps,
+			OriginalObject:  obj,
 		}
 
 		return
@@ -167,6 +177,7 @@ func (n *netPolsEventHandler) Update(ue event.UpdateEvent, wq workqueue.RateLimi
 			Type:            sdwan.OperationRemove,
 			ApplicationName: curr.Name,
 			Servers:         oldParsedIps,
+			OriginalObject:  obj,
 		}
 	}
 
@@ -180,6 +191,7 @@ func (n *netPolsEventHandler) Update(ue event.UpdateEvent, wq workqueue.RateLimi
 		Type:            sdwan.OperationAdd,
 		ApplicationName: curr.Name,
 		Servers:         currParsedIps,
+		OriginalObject:  obj,
 	}
 }
 
@@ -215,6 +227,10 @@ func (n *netPolsEventHandler) Delete(de event.DeleteEvent, wq workqueue.RateLimi
 		Type:            sdwan.OperationRemove,
 		ApplicationName: netpol.Name,
 		Servers:         parsedIps,
+		OriginalObject: annotations.Object{
+			Name: types.NamespacedName{Name: netpol.Name, Namespace: netpol.Namespace},
+			Type: annotations.NetworkPolicy,
+		},
 	}
 }
 
@@ -252,6 +268,10 @@ func (n *netPolsEventHandler) Create(ce event.CreateEvent, wq workqueue.RateLimi
 		Type:            sdwan.OperationAdd,
 		ApplicationName: netpol.Name,
 		Servers:         parsedIps,
+		OriginalObject: annotations.Object{
+			Name: types.NamespacedName{Name: netpol.Name, Namespace: netpol.Namespace},
+			Type: annotations.NetworkPolicy,
+		},
 	}
 }
 

--- a/pkg/controllers/service_entry.go
+++ b/pkg/controllers/service_entry.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco Systems, Inc. and its affiliates
+// Copyright (c) 2022, 2023 Cisco Systems, Inc. and its affiliates
 // All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,12 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/CloudNativeSDWAN/egress-watcher/pkg/annotations"
 	"github.com/CloudNativeSDWAN/egress-watcher/pkg/sdwan"
 	"github.com/rs/zerolog"
 	netv1b1 "istio.io/api/networking/v1beta1"
 	vb1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/util/workqueue"
@@ -112,6 +114,10 @@ func (s *serviceEntryEventHandler) Update(ue event.UpdateEvent, wq workqueue.Rat
 			Type:            sdwan.OperationRemove,
 			ApplicationName: curr.Name,
 			Servers:         oldParsedHosts,
+			OriginalObject: annotations.Object{
+				Name: types.NamespacedName{Name: curr.Name, Namespace: curr.Namespace},
+				Type: annotations.ServiceEntry,
+			},
 		}
 		return
 	}
@@ -131,6 +137,10 @@ func (s *serviceEntryEventHandler) Update(ue event.UpdateEvent, wq workqueue.Rat
 				Type:            sdwan.OperationRemove,
 				ApplicationName: curr.Name,
 				Servers:         oldParsedHosts,
+				OriginalObject: annotations.Object{
+					Name: types.NamespacedName{Name: curr.Name, Namespace: curr.Namespace},
+					Type: annotations.ServiceEntry,
+				},
 			}
 			return
 		}
@@ -152,6 +162,10 @@ func (s *serviceEntryEventHandler) Update(ue event.UpdateEvent, wq workqueue.Rat
 					Type:            sdwan.OperationRemove,
 					ApplicationName: curr.Name,
 					Servers:         oldParsedHosts,
+					OriginalObject: annotations.Object{
+						Name: types.NamespacedName{Name: curr.Name, Namespace: curr.Namespace},
+						Type: annotations.ServiceEntry,
+					},
 				}
 
 				// ... then, add
@@ -159,6 +173,10 @@ func (s *serviceEntryEventHandler) Update(ue event.UpdateEvent, wq workqueue.Rat
 					Type:            sdwan.OperationAdd,
 					ApplicationName: curr.Name,
 					Servers:         currParsedHosts,
+					OriginalObject: annotations.Object{
+						Name: types.NamespacedName{Name: curr.Name, Namespace: curr.Namespace},
+						Type: annotations.ServiceEntry,
+					},
 				}
 			}
 		}
@@ -178,6 +196,10 @@ func (s *serviceEntryEventHandler) Update(ue event.UpdateEvent, wq workqueue.Rat
 			Type:            sdwan.OperationRemove,
 			ApplicationName: curr.Name,
 			Servers:         oldParsedHosts,
+			OriginalObject: annotations.Object{
+				Name: types.NamespacedName{Name: curr.Name, Namespace: curr.Namespace},
+				Type: annotations.ServiceEntry,
+			},
 		}
 
 		return
@@ -197,6 +219,10 @@ func (s *serviceEntryEventHandler) Update(ue event.UpdateEvent, wq workqueue.Rat
 		Type:            sdwan.OperationRemove,
 		ApplicationName: curr.Name,
 		Servers:         oldParsedHosts,
+		OriginalObject: annotations.Object{
+			Name: types.NamespacedName{Name: curr.Name, Namespace: curr.Namespace},
+			Type: annotations.ServiceEntry,
+		},
 	}
 
 	// ... then, add
@@ -204,6 +230,10 @@ func (s *serviceEntryEventHandler) Update(ue event.UpdateEvent, wq workqueue.Rat
 		Type:            sdwan.OperationAdd,
 		ApplicationName: curr.Name,
 		Servers:         currParsedHosts,
+		OriginalObject: annotations.Object{
+			Name: types.NamespacedName{Name: curr.Name, Namespace: curr.Namespace},
+			Type: annotations.ServiceEntry,
+		},
 	}
 }
 
@@ -233,6 +263,10 @@ func (s *serviceEntryEventHandler) Delete(de event.DeleteEvent, wq workqueue.Rat
 		Type:            sdwan.OperationRemove,
 		ApplicationName: se.Name,
 		Servers:         parsedHosts,
+		OriginalObject: annotations.Object{
+			Name: types.NamespacedName{Name: se.Name, Namespace: se.Namespace},
+			Type: annotations.ServiceEntry,
+		},
 	}
 }
 
@@ -276,6 +310,10 @@ func (s *serviceEntryEventHandler) Create(ce event.CreateEvent, wq workqueue.Rat
 		Type:            sdwan.OperationAdd,
 		ApplicationName: se.Name,
 		Servers:         parsedHosts,
+		OriginalObject: annotations.Object{
+			Name: types.NamespacedName{Name: se.Name, Namespace: se.Namespace},
+			Type: annotations.ServiceEntry,
+		},
 	}
 }
 

--- a/pkg/sdwan/operations.go
+++ b/pkg/sdwan/operations.go
@@ -17,6 +17,10 @@
 
 package sdwan
 
+import (
+	"github.com/CloudNativeSDWAN/egress-watcher/pkg/annotations"
+)
+
 type OperationType string
 
 const (
@@ -28,4 +32,6 @@ type Operation struct {
 	Type            OperationType
 	ApplicationName string
 	Servers         []string
+
+	OriginalObject annotations.Object
 }


### PR DESCRIPTION
This PR allows the egress watcher to annotate a supported Kubernetes object -- i.e. a `ServiceEntry` or `NetworkPolicy` -- with key that notify whether it was inserted or enabled on the chosen SDWAN.

For example, after `kubectl apply`ing a `ServiceEntry` correctly, egress watcher will *annotate* it with `egress-watcher.cnwan.io/sdwan-populated` after it receives a confirmation that it was successfully inserted, and `"egress-watcher.cnwan.io/sdwan-enabled" after a successful configuration/policy update from SDWAN.