### PR TITLE
Introduce `enable` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ verbose) to `3` (only log important errors). Default is `1`.
   disable it entirely. For example, if you set `1m`, Egress Watcher will
   wait one minute for other changes to appear before applying them in
   order to improve performance and do bulk operations. Default is `30s`.
+* `--sdwan.enable`: whether to enable/disable the configuration/policies
+  for the added applicaitons. By default, this is not enabled, which means
+  that the egress watcher will just add/update/delete applications and will
+  not enable or disable the policies that apply them.
 
 As a rule of thumb, remember that flag options **overwrite** options provided
 via file.

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -264,7 +264,7 @@ func runWithVmanage(kopts *kubeConfigOptions, opts *Options) error {
 		}
 		log.Info().Msg("successfully retrieved client for vManage")
 
-		return vmanage.NewOperationsHandler(vclient, *opts.Sdwan.WaitingWindow, log)
+		return vmanage.NewOperationsHandler(vclient, *opts.Sdwan, log)
 	}()
 	if err != nil {
 		return fmt.Errorf("cannot start operations handler for "+

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -177,6 +177,10 @@ The following controllers are supported:
 				fileOpts.Verbosity = flagOpts.Verbosity
 			}
 
+			if cmd.Flag("sdwan.enable").Changed {
+				fileOpts.Sdwan.Enable = flagOpts.Sdwan.Enable
+			}
+
 			if cmd.Flag("watch-all-network-policies").Changed {
 				fileOpts.NetworkPolicyController.WatchAllNetworkPolicies = flagOpts.NetworkPolicyController.WatchAllNetworkPolicies
 			}
@@ -228,6 +232,9 @@ The following controllers are supported:
 	cmd.Flags().DurationVar(flagOpts.Sdwan.WaitingWindow,
 		"waiting-window", sdwan.DefaultWaitingWindow,
 		"the duration of the waiting mode. Set this to 0 to disable it entirely.")
+	cmd.Flags().BoolVarP(&flagOpts.Sdwan.Enable,
+		"sdwan.enable", "e", false,
+		"whether to also apply configuration/policies.")
 
 	return cmd
 }

--- a/pkg/sdwan/options.go
+++ b/pkg/sdwan/options.go
@@ -34,5 +34,6 @@ type Options struct {
 	BaseURL        string         `yaml:"baseUrl"`
 	Insecure       bool           `yaml:"insecure"`
 	WaitingWindow  *time.Duration `yaml:"waitingWindow"`
+	Enable         bool           `yaml:"enable"`
 	Authentication *Authentication
 }

--- a/settings.yaml
+++ b/settings.yaml
@@ -3,12 +3,13 @@
 serviceEntry:
   watchAllServiceEntries: false
 networkPolicy:
-  watchAllNetworkPolicies: false 
+  watchAllNetworkPolicies: false
 sdwan:
   # Base URL where to reach sdwan's API,
   # e.g: https://example.com:9876/api
   baseUrl: <base_url>
   insecure: false
   waitingWindow: 30s
+  enable: false
 prettyLogs: false
 verbosity: 1


### PR DESCRIPTION
This PR introduces the ability to choose whether to only insert data on SDWAN's database and stop there, or continue with enabling the application, i.e. applying configuration/policies, depending on the chosen SDWAN.

This happens either via `--enable` CLI flag or the `enable` setting field.