### PR TITLE
Fix: reject all non-`MESH_EXTERNAL` Service Entries

### DIFF
--- a/pkg/sdwan/vmanage/operation.go
+++ b/pkg/sdwan/vmanage/operation.go
@@ -141,12 +141,18 @@ func (v *Client) WatchForOperations(mainCtx context.Context, opsChan chan *sdwan
 				}
 			}
 
-			if mainCtx.Err() != nil {
+			log.Debug().Dur("duration", 5*time.Second).
+				Msg("cooling down...")
+			coolDown := time.NewTimer(5 * time.Second)
+			select {
+			case <-mainCtx.Done():
 				// Avoid adding custom applications, then.
 				return nil
+			case <-coolDown.C:
+				log.Debug().Msg("finished cool down")
 			}
 
-			// -- The, add the new applications
+			// -- Then, add the new applications
 			if len(toAdd) > 0 {
 				if err := doAction(toAdd); err != nil {
 					log.Err(err).Msg("error while adding custom applications")


### PR DESCRIPTION
This PR fixes #90 by rejecting any service entry that is neither `MESH_EXTERNAL` nor `DNS`. 
Read the issue for more information about that.

Additionally, this also adds a little -- 5 seconds -- cool down period before starting another operation on vManage. This may be tuned or removed in future, according to how this will behave.