### PR TITLE
Improve install command

### DIFF
--- a/artifacts/yamls/k8s/01_service_account.yaml
+++ b/artifacts/yamls/k8s/01_service_account.yaml
@@ -9,30 +9,20 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: egress-watcher-role
+  name: egress-watcher-cluster-role
 rules:
-- apiGroups:
-  - networking.istio.io
-  resources:
-  - serviceentries
-  verbs:
-  - watch
-  - get
-  - list
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-  - get
-  - list
+  - apiGroups: ["networking.istio.io"]
+    resources: ["serviceentries"]
+    verbs: ["watch", "get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["watch", "get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
-  name: egress-watcher-role-binding
+  name: egress-watcher-cluster-role-binding
 subjects:
   - kind: ServiceAccount
     name: egress-watcher-service-account
@@ -40,4 +30,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: egress-watcher-role
+  name: egress-watcher-cluster-role

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/CloudNativeSDWAN/egress-watcher
 go 1.18
 
 require (
+	github.com/google/go-github v17.0.0+incompatible
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/term v0.5.0
@@ -31,6 +32,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/CloudNativeSDWAN/egress-watcher
 go 1.18
 
 require (
+	github.com/enescakir/emoji v1.0.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/enescakir/emoji v1.0.0 h1:W+HsNql8swfCQFtioDGDHCHri8nudlK1n5p2rHCJoog=
+github.com/enescakir/emoji v1.0.0/go.mod h1:Bt1EKuLnKDTYpLALApstIkAjdDrS/8IAgTkKp+WKFD0=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,15 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -289,6 +289,6 @@ func installInteractivelyToK8s(clientset *kubernetes.Clientset) error {
 		Verbosity:  sdwan_verbosity,
 	}
 
+	fmt.Println()
 	return install(clientset, dockerImage, opt)
-
 }

--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -214,9 +214,7 @@ func install(clientset *kubernetes.Clientset, docker_image string, opt Options) 
 }
 
 func installInteractivelyToK8s(clientset *kubernetes.Clientset) error {
-	//take various inputs from user
-
-	//Username
+	// Username
 	var sdwan_username string
 	for {
 		fmt.Print("Please enter your SDWAN username: ")
@@ -227,7 +225,7 @@ func installInteractivelyToK8s(clientset *kubernetes.Clientset) error {
 		fmt.Println("username provided is invalid")
 	}
 
-	//Password
+	// Password
 	var sdwan_password string
 	for {
 		fmt.Print("Please enter your sdwan password (input will be hidden): ")
@@ -240,7 +238,7 @@ func installInteractivelyToK8s(clientset *kubernetes.Clientset) error {
 	}
 	fmt.Println()
 
-	//Baseurl
+	// Base URL
 	var sdwan_base_url string
 	for {
 		fmt.Print("Please enter your SDWAN base URL, e.g. https://example.com: ")
@@ -266,7 +264,7 @@ func installInteractivelyToK8s(clientset *kubernetes.Clientset) error {
 		fmt.Println("Provided duration is invalid")
 	}
 
-	//self signed certificate
+	// Self-signed certificates
 	sdwan_insecure := false
 selfSignedCertificate:
 	for {
@@ -287,7 +285,6 @@ selfSignedCertificate:
 	}
 
 	// Verbosity
-
 	sdwan_verbosity := defaultVerbosity
 	for {
 		var inputVerbosity string
@@ -309,7 +306,7 @@ selfSignedCertificate:
 		fmt.Println("Provided invalid verbosity value")
 	}
 
-	// PrettyLogs
+	// Pretty logs
 	sdwan_prettylogs := false
 prettyLogsInput:
 	for {
@@ -328,8 +325,8 @@ prettyLogsInput:
 		}
 	}
 
-	// Watch all services
-	watchall_serviceentries := false
+	// Watch all service entries
+	watchAllServiceEntries := false
 watchAllServicesInput:
 	for {
 		fmt.Print("Do you want to watch all ServiceEntry resources? [y/n] (default: n): ")
@@ -339,11 +336,28 @@ watchAllServicesInput:
 
 		switch strings.ToLower(user_input) {
 		case "y":
-			watchall_serviceentries = true
+			watchAllServiceEntries = true
 			break watchAllServicesInput
 		case "", "n":
 			break watchAllServicesInput
+		}
+	}
 
+	// Watch all network policies
+	watchAllNetPols := false
+whatchAllNetPolsInput:
+	for {
+		fmt.Print("Do you want to watch all NetworkPolicy resources? [y/n] (default: n): ")
+
+		var user_input string
+		fmt.Scanln(&user_input)
+
+		switch strings.ToLower(user_input) {
+		case "y":
+			watchAllNetPols = true
+			break whatchAllNetPolsInput
+		case "", "n":
+			break whatchAllNetPolsInput
 		}
 	}
 
@@ -359,7 +373,10 @@ watchAllServicesInput:
 
 	opt := Options{
 		ServiceEntryController: &controllers.ServiceEntryOptions{
-			WatchAllServiceEntries: watchall_serviceentries,
+			WatchAllServiceEntries: watchAllServiceEntries,
+		},
+		NetworkPolicyController: &controllers.NetworkPolicyOptions{
+			WatchAllNetworkPolicies: watchAllNetPols,
 		},
 
 		Sdwan: &sdwan.Options{

--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -218,6 +218,23 @@ func install(clientset *kubernetes.Clientset, dockerImage string, opt Options) e
 }
 
 func installInteractivelyToK8s(clientset *kubernetes.Clientset) error {
+	askYesNo := func() bool {
+		// Utility function to ask for yes or no with no as default.
+		for {
+			var user_input string
+			fmt.Scanln(&user_input)
+
+			switch strings.ToLower(user_input) {
+			case "y":
+				return true
+			case "", "n":
+				return false
+			}
+
+			fmt.Printf("invalid input, please try again: [y/n] (default: n): ")
+		}
+	}
+
 	// Username
 	var sdwan_username string
 	for {
@@ -269,24 +286,8 @@ func installInteractivelyToK8s(clientset *kubernetes.Clientset) error {
 	}
 
 	// Self-signed certificates
-	sdwan_insecure := false
-selfSignedCertificate:
-	for {
-		fmt.Print("Do you want to accept self-signed certificates? [y/n] (default: n): ")
-
-		var user_input string
-		fmt.Scanln(&user_input)
-
-		switch strings.ToLower(user_input) {
-		case "y":
-			sdwan_insecure = true
-			break selfSignedCertificate
-		case "", "n":
-			break selfSignedCertificate
-
-		}
-
-	}
+	fmt.Print("Do you want to accept self-signed certificates? [y/n] (default: n): ")
+	sdwan_insecure := askYesNo()
 
 	// Verbosity
 	sdwan_verbosity := defaultVerbosity
@@ -311,63 +312,20 @@ selfSignedCertificate:
 	}
 
 	// Pretty logs
-	sdwan_prettylogs := false
-prettyLogsInput:
-	for {
-		fmt.Print("Do you need pretty logs? [y/n] (default: n): ")
-
-		var user_input string
-		fmt.Scanln(&user_input)
-
-		switch strings.ToLower(user_input) {
-		case "y":
-			sdwan_prettylogs = true
-			break prettyLogsInput
-		case "", "n":
-			break prettyLogsInput
-
-		}
-	}
+	fmt.Print("Do you need human-readable logs? [y/n] (default: n): ")
+	sdwan_prettylogs := askYesNo()
 
 	// Watch all service entries
-	watchAllServiceEntries := false
-watchAllServicesInput:
-	for {
-		fmt.Print("Do you want to watch all ServiceEntry resources? [y/n] (default: n): ")
-
-		var user_input string
-		fmt.Scanln(&user_input)
-
-		switch strings.ToLower(user_input) {
-		case "y":
-			watchAllServiceEntries = true
-			break watchAllServicesInput
-		case "", "n":
-			break watchAllServicesInput
-		}
-	}
+	fmt.Print("Do you want to watch all ServiceEntry resources? [y/n] (default: n): ")
+	watchAllServiceEntries := askYesNo()
 
 	// Watch all network policies
-	watchAllNetPols := false
-whatchAllNetPolsInput:
-	for {
-		fmt.Print("Do you want to watch all NetworkPolicy resources? [y/n] (default: n): ")
-
-		var user_input string
-		fmt.Scanln(&user_input)
-
-		switch strings.ToLower(user_input) {
-		case "y":
-			watchAllNetPols = true
-			break whatchAllNetPolsInput
-		case "", "n":
-			break whatchAllNetPolsInput
-		}
-	}
+	fmt.Print("Do you want to watch all NetworkPolicy resources? [y/n] (default: n): ")
+	watchAllNetPols := askYesNo()
 
 	// Docker Image
 	dockerImage := ""
-	fmt.Printf("Enter docker image (default: latest official release): ")
+	fmt.Printf("Enter docker image (press enter for latest official release): ")
 	var user_input string
 	fmt.Scanln(&user_input)
 

--- a/pkg/command/install.go
+++ b/pkg/command/install.go
@@ -47,6 +47,8 @@ const (
 func getInstallCommand() *cobra.Command {
 	interactive := false
 	waitingWindow := defaultWaitingWindow
+	containerImage := ""
+
 	opts := Options{
 		ServiceEntryController: &controllers.ServiceEntryOptions{
 			WatchAllServiceEntries: false,
@@ -94,7 +96,7 @@ func getInstallCommand() *cobra.Command {
 			}
 
 			opts.Sdwan.Authentication.Password = askForPassword()
-			return install(clientset, "", opts)
+			return install(clientset, containerImage, opts)
 
 		},
 		Example: "install --username myself --password password " +
@@ -128,6 +130,9 @@ func getInstallCommand() *cobra.Command {
 	cmd.Flags().DurationVar(opts.Sdwan.WaitingWindow,
 		"waiting-window", sdwan.DefaultWaitingWindow,
 		"the duration of the waiting mode. Set this to 0 to disable it entirely.")
+	cmd.Flags().StringVar(&containerImage,
+		"image", "",
+		"the container's image. If blank, the latest official one will be used.")
 
 	return cmd
 }

--- a/pkg/command/install_utils.go
+++ b/pkg/command/install_utils.go
@@ -22,9 +22,11 @@ package command
 import (
 	"context"
 	"fmt"
+	"syscall"
 	"time"
 
 	"github.com/enescakir/emoji"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -444,4 +446,17 @@ func (i *installer) cleanUp(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func askForPassword() (pass string) {
+	for {
+		fmt.Print("Please enter your SDWAN password (input will be hidden): ")
+		bytePassword, _ := term.ReadPassword(int(syscall.Stdin))
+		pass = string(bytePassword)
+		if pass != "" {
+			return
+		}
+
+		fmt.Println("password provided is invalid")
+	}
 }

--- a/pkg/command/install_utils.go
+++ b/pkg/command/install_utils.go
@@ -77,9 +77,17 @@ func createClusterRole(clientset *kubernetes.Clientset, usernamespace, name stri
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{
-					"networking.istio.io"},
+				APIGroups: []string{"networking.istio.io"},
 				Resources: []string{"serviceentries"},
+				Verbs: []string{
+					"watch",
+					"get",
+					"list",
+				},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"networkpolicies"},
 				Verbs: []string{
 					"watch",
 					"get",


### PR DESCRIPTION
This PR continues @chowndarya's good work on the `install` command and adds a few things that were planned but were unimplemented.

*  Installation also works with `NetworkPolicy`
* When a blank container image is provided, the latest **versioned** official one is used by default (e.g. `ghcr.io/cloudnativesdwan/egress-watcher:v0.5.1`, please note the `v0.5.1` and not `latest`)
* Some code refactoring to avoid repetition
* Skip creation of namespace and service account if they already exist
* Skip deletion of namespace and service account on clean up if they already existed before
* Update resource names and flags to be consistent